### PR TITLE
- Upgraded tensorflow-core-platform to 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ gradle/
 gradlew*
 
 .idea
+
+.DS_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ configure<io.vacco.oss.gitflow.GsPluginProfileExtension> {
 val api by configurations
 
 dependencies {
-  api("org.tensorflow:tensorflow-core-platform:0.4.1")
+  api("org.tensorflow:tensorflow-core-platform:0.5.0")
   testImplementation("com.robrua.nlp.models:easy-bert-uncased-L-12-H-768-A-12:1.0.0")
   testImplementation("com.google.code.gson:gson:2.10.1")
 }

--- a/src/main/java/io/vacco/bertastic/BtSession.java
+++ b/src/main/java/io/vacco/bertastic/BtSession.java
@@ -1,5 +1,6 @@
 package io.vacco.bertastic;
 
+import org.tensorflow.Result;
 import org.tensorflow.SavedModelBundle;
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.StdArrays;
@@ -83,12 +84,12 @@ public class BtSession implements AutoCloseable {
    */
   public float[][] embedSequences(String ... sequences) {
     try (var inputs = getInputs(sequences)) {
-      List<Tensor> output = bundle.session().runner()
-          .feed(model.inputIds, inputs.inputIds)
-          .feed(model.inputMask, inputs.inputMask)
-          .feed(model.segmentIds, inputs.segmentIds)
-          .fetch(model.pooledOutput)
-          .run();
+      Result output = bundle.session().runner()
+                            .feed(model.inputIds, inputs.inputIds)
+                            .feed(model.inputMask, inputs.inputMask)
+                            .feed(model.segmentIds, inputs.segmentIds)
+                            .fetch(model.pooledOutput)
+                            .run();
       try (var embedding = output.get(0)) {
         return StdArrays.array2dCopyOf((TFloat32) embedding);
       }


### PR DESCRIPTION
The latest version of the Java Tensorflow API has a small breaking change. The return result of the session runner changed from `List<Tensor>` to a `Result` return type.

This patch makes Bertastic compatible with the latest version of Tensorflow for Java.